### PR TITLE
Add 'remember me' option at login (fixes #25)

### DIFF
--- a/cmsocial-web/scripts/l10n.js
+++ b/cmsocial-web/scripts/l10n.js
@@ -285,6 +285,9 @@ angular.module('cmsocial')
     'Log out': {
       it: 'Esci'
     },
+    'Stay signed in': {
+      it: 'Resta connesso'
+    },
     'Forgot account?':
     {it: 'Hai dimenticato le credenziali?'},
     'No such user':

--- a/cmsocial-web/scripts/user.js
+++ b/cmsocial-web/scripts/user.js
@@ -134,6 +134,7 @@ angular.module('cmsocial')
           'action': 'login',
           'username': $scope.user.username,
           'password': $scope.user.password,
+          'keep_signed': $("#keep_signed").prop("checked")
         })
         .success(function(data, status, headers, config) {
           if (data.success == 1) {

--- a/cmsocial-web/styles/main.less
+++ b/cmsocial-web/styles/main.less
@@ -58,9 +58,19 @@ a.dont-underline:hover {
 }
 
 .signin-form {
-  width: 250px;
+  width: 300px;
   padding: 15px;
   padding-bottom: 8px;
+}
+
+.navbar label {
+  font-weight: 100;
+}
+
+@media only screen and (max-width : 768px) {
+  .navbar label {
+    color: #9d9d9d;
+  }
 }
 
 /* Notification alerts */

--- a/cmsocial-web/views/navbar.html
+++ b/cmsocial-web/views/navbar.html
@@ -43,7 +43,15 @@
                 <label class="sr-only" for="password">{{'Password' | l10n}}</label>
                 <input class="form-control" type="password" id="password" name="password" ng-model="user.password" placeholder="Password" />
               </div>
-              <button type="submit" class="btn btn-success"><i class="fa fa-sign-in"></i> {{'Log in' | l10n}}</button>
+              <div class="row vertical-center">
+                <div class="col-xs-8">
+                  <input type="checkbox" id="keep_signed" name="keep_signed" checked="checked" />
+                  <label for="keep_signed">{{'Stay signed in' | l10n}}</label>
+                </div>
+                <div class="col-xs-4">
+                  <button type="submit" class="btn btn-success pull-right"><i class="fa fa-sign-in"></i> {{'Log in' | l10n}}</button>
+                </div>
+              </div>
               <div class="form-group" style="margin: 6px 0px 0px 0px" ng-if="cm.getContest().mail_enabled">
                 <a data-toggle="dropdown" ui-sref="forgot-account">{{'Forgot account?' | l10n}}</a>
               </div>

--- a/cmsocial/server/pws.py
+++ b/cmsocial/server/pws.py
@@ -695,9 +695,15 @@ class APIHandler(object):
                     return 'login.error'
             else:
                 local.user = participation.user
+
+            # When the user explicitly requests, make the cookie expire
+            # after 30 days (instead of at the end of the browser's session).
+            keep_signed = local.data.get('keep_signed', False)
+            cookie_duration = 30 * 86400 if keep_signed else None
             local.response = Response()
             local.response.set_cookie(
                 'token', value=self.build_token(),
+                max_age = cookie_duration,
                 domain=local.contest.social_contest.cookie_domain)
         elif local.data['action'] == 'me':
             if local.user is None:


### PR DESCRIPTION
When selected, the auth cookie expires after 30 days instead of at the
end of the browser's session.