### PR TITLE
Switch to cdnjs as CDN for Mathjax

### DIFF
--- a/cmsocial-web/index.html
+++ b/cmsocial-web/index.html
@@ -32,9 +32,9 @@
     <script src="node_modules/angular-touch/angular-touch.js" cdn="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-touch.min.js"></script>
     <script src="node_modules/angular-ui-router/release/angular-ui-router.js" cdn="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.15/angular-ui-router.min.js"></script>
     <script src="node_modules/angular-md5/angular-md5.js" cdn="https://cdnjs.cloudflare.com/ajax/libs/angular-md5/0.1.10/angular-md5.min.js"></script>
+    <script src="node_modules/mathjax/MathJax.js?config=TeX-AMS_HTML" cdn="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
     <script src="node_modules/ace-builds/src-min-noconflict/ace.js" cdn="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js"></script>
     <script src="node_modules/angular-ui-ace/src/ui-ace.js" cdn="https://cdn.rawgit.com/angular-ui/ui-ace/v0.2.3/ui-ace.min.js"></script>
-    <script src="node_modules/mathjax/MathJax.js?config=TeX-AMS_HTML" cdn="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
     <script src="node_modules/commonmark/dist/commonmark.js" cdn="https://unpkg.com/commonmark@0.27.0/dist/commonmark.min.js"></script>
     <script src="node_modules/babel-polyfill/dist/polyfill.js" cdn="https://unpkg.com/babel-polyfill@6.23.0/dist/polyfill.min.js"></script>
     <script src="COMMIT_ID_HERE/scripts/app.js"></script>


### PR DESCRIPTION
The old CDN has been discontinued, see here:
https://www.mathjax.org/cdn-shutting-down/