### PR TITLE
Fix #29 (submissions of output-only tasks)

### DIFF
--- a/cmsocial/server/pws.py
+++ b/cmsocial/server/pws.py
@@ -1648,7 +1648,7 @@ Recovery code: %s""" % (user.username, user.social_user.recover_code)):
             # Add the submission
             timestamp = make_datetime()
             submission = Submission(timestamp,
-                                    sub_lang.name,
+                                    getattr(sub_lang, "name", None),
                                     participation=local.participation,
                                     task=task)
             for f in files:


### PR DESCRIPTION
Properly set the language of output-only task submissions to `None` .

See this reference in the database description: https://github.com/algorithm-ninja/cms/blob/future/cms/db/submission.py#L90

Fixes #29.