### PR TITLE
Properly clear old cookie when failing authentication

### DIFF
--- a/cmsocial-web/scripts/user.js
+++ b/cmsocial-web/scripts/user.js
@@ -33,25 +33,26 @@ angular.module('cmsocial')
     };
 
     const clearCookies = function() {
-      // Remove cookies
-      $cookies.remove('token_digit', {
-        domain: contestManager.getContest().cookie_domain,
-        path: '/'
-      });
-      $cookies.remove('token', {
-        domain: contestManager.getContest().cookie_domain,
-        path: '/'
-      });
+      // Remove cookies: reading the cookie_domain from DB is the right way, but it's currently
+      // unreliable because the call to /api/contest might not have finished yet and
+      // contestManager.getContest() will be null. For now we fallback to mapping:
+      //   'token' -> 'olinfo.it'
+      //   'token_digit' -> 'digit.olinfo.it'
+      // but we should fix this by using promises and properly 'await'-ing this call.
+      const cookieDomain = contestManager.getContest()?.cookie_domain;
+      const tokenName = location.host.startsWith("digit.") ? 'token_digit' : 'token';
 
-      // Remove old cookies that could be stuck
-      $cookies.remove('token_digit', {
-        domain: 'digit.olinfo.it',
-        path: '/'
-      });
-      $cookies.remove('token', {
-        domain: 'training.olinfo.it',
-        path: '/'
-      });
+      if (cookieDomain !== null) {
+        $cookies.remove(tokenName, {
+          domain: cookieDomain,
+          path: '/'
+        });
+      } else {
+        $cookies.remove(tokenName, {
+          domain: tokenName === 'token' ? 'olinfo.it' : 'digit.olinfo.it',
+          path: '/'
+        });
+      }
     };
 
     const refreshUser = function() {

--- a/cmsocial/server/pws.py
+++ b/cmsocial/server/pws.py
@@ -740,8 +740,15 @@ class APIHandler(object):
                 value=self.build_token(),
                 max_age=cookie_duration,
                 domain=local.contest.social_contest.cookie_domain)
+        elif local.data['action'] == 'logout':
+            local.response.delete_cookie(
+                'token' if local.contest.social_contest.title != u'MIUR \u2014 Corso Competenze Digitali' else 'token_digit',
+                domain=local.contest.social_contest.cookie_domain)
         elif local.data['action'] == 'me':
             if local.user is None:
+                local.response.delete_cookie(
+                    'token' if local.contest.social_contest.title != u'MIUR \u2014 Corso Competenze Digitali' else 'token_digit',
+                    domain=local.contest.social_contest.cookie_domain)
                 return 'Unauthorized'
             if local.participation is None:
                 local.resp['user'] = self.get_user_info(local.user)


### PR DESCRIPTION
This should fix the issue with users getting "stuck" after we change the server secret.

Not tested.